### PR TITLE
When generate TWRP device tree often error in fstab where not all rows contain all elements

### DIFF
--- a/sebaubuntu_libs/libandroid/fstab/__init__.py
+++ b/sebaubuntu_libs/libandroid/fstab/__init__.py
@@ -39,7 +39,7 @@ class FstabEntry:
 
 	@classmethod
 	def from_entry(cls, line: str):
-		src, mount_point, fs_type, mnt_flags, fs_flags = line.split()
+		src, mount_point, fs_type, mnt_flags, fs_flags, *_ = line.split()+ ['']+ ['']
 
 		return cls(src, mount_point, fs_type, mnt_flags.split(','), fs_flags.split(','))
 


### PR DESCRIPTION
Fix for
```
  File "/home/sltx/pyvenv/lib/python3.11/site-packages/sebaubuntu_libs/libandroid/fstab/__init__.py", line 59, in __init__
    self.entries.append(FstabEntry.from_entry(line))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sltx/pyvenv/lib/python3.11/site-packages/sebaubuntu_libs/libandroid/fstab/__init__.py", line 42, in from_entry
    src, mount_point, fs_type, mnt_flags, fs_flags = line.split()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 5, got 3)
```